### PR TITLE
Project setting about webpack config & babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,7 @@
 {
   "presets": [
     ["env", {
-      "modules": false,
-      "targets": {
-        "browsers": ["> 1%", "last 2 versions", "not ie <= 8"]
-      }
+      "modules": false
     }]
   ],
   "plugins": [

--- a/build/webpack.config.base.js
+++ b/build/webpack.config.base.js
@@ -46,6 +46,10 @@ module.exports = {
         use: 'vue-loader'
       }, {
         test: /\.js$/,
+        include: [
+          utils.resolve('src'),
+          utils.resolve('test'),
+        ],
         use: {
           loader: 'babel-loader',
           options: {


### PR DESCRIPTION
Webpack babel-loader need include (or exclude);
Babel settings have set by package.json yet.